### PR TITLE
Error message rendered with b' prefix in py3

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ Retwist comes with a [tox configuration](tox.ini) to run its test suite on all s
 linting and type checking step.
 
 It's possible to install all required Python versions locally via [pyenv](https://github.com/pyenv/pyenv).
-Alternatively, use the [sawkita/tox Docker image](https://github.com/acerv/tox-docker) to run the test suite:
+Alternatively, use the [kiwicom/tox Docker image](https://hub.docker.com/r/kiwicom/tox) to run the test suite:
 
 ```shell
-docker pull sawkita/tox:all
+docker pull kiwicom/tox
 
 docker container run \
     --mount src=$PWD,target=/retwist,type=bind \
     --interactive --tty --rm \
     --dns 8.8.8.8 \  # Prevents a DNS issue which occurs on some Linux hosts. This is a Google DNS server, but any other would work too
-    sawkita/tox:all \
+    kiwicom/tox \
     /bin/bash -c "cd /retwist && find -name '*.pyc' -delete && tox"  # Delete stale *.pyc files to avoid errors on Python 2
 ```

--- a/retwist/param.py
+++ b/retwist/param.py
@@ -280,10 +280,12 @@ class UUIDParam(BaseParam[UUID]):
     Parameter that verifies it's a valid UUID.
     """
 
+    MALFORMED_ERROR_MSG = b"Malformed UUID"
+
     def parse(self, val):
         # type: (bytes) -> UUID
         val_str = val.decode()
         try:
             return UUID(val_str)
         except ValueError:
-            raise Error(BAD_REQUEST, message=b"Malformed UUID")
+            raise Error(BAD_REQUEST, message=UUIDParam.MALFORMED_ERROR_MSG)

--- a/retwist/param_resource.py
+++ b/retwist/param_resource.py
@@ -37,7 +37,7 @@ class ParamResource(Resource):
             try:
                 val = param.parse_from_request(name, request)
             except Error as ex:
-                error_msg = "Error in parameter {}: {}".format(name, ex.message.decode()).encode("utf-8")
+                error_msg = b"Error in parameter %s: %s" % (name.encode(), ex.message)
                 raise Error(ex.status, error_msg)
             else:
                 args[name] = val

--- a/retwist/param_resource.py
+++ b/retwist/param_resource.py
@@ -37,7 +37,7 @@ class ParamResource(Resource):
             try:
                 val = param.parse_from_request(name, request)
             except Error as ex:
-                error_msg = "Error in parameter {}: {}".format(name, ex.message).encode("utf-8")
+                error_msg = "Error in parameter {}: {}".format(name, ex.message.decode()).encode("utf-8")
                 raise Error(ex.status, error_msg)
             else:
                 args[name] = val

--- a/retwist/param_resource.py
+++ b/retwist/param_resource.py
@@ -19,6 +19,8 @@ class ParamResource(Resource):
     You can then retrieve parameters by calling parse_args(request) in your render_* method.
     """
 
+    ERROR_MSG = b"Error in parameter %s: %s"
+
     def parse_args(self, request):
         # type: (Request) -> Dict[str, Any]
         """
@@ -37,7 +39,7 @@ class ParamResource(Resource):
             try:
                 val = param.parse_from_request(name, request)
             except Error as ex:
-                error_msg = b"Error in parameter %s: %s" % (name.encode(), ex.message)
+                error_msg = ParamResource.ERROR_MSG % (name.encode(), ex.message)
                 raise Error(ex.status, error_msg)
             else:
                 args[name] = val

--- a/tests/test_param_resource.py
+++ b/tests/test_param_resource.py
@@ -1,4 +1,6 @@
+import pytest
 from twisted.web.test.requesthelper import DummyRequest
+from twisted.web.error import Error
 
 import retwist
 
@@ -6,6 +8,7 @@ import retwist
 class DemoPage(retwist.ParamResource):
 
     id = retwist.Param(required=True)
+    uuid = retwist.UUIDParam()
     show_details = retwist.BoolParam()
     def_param = retwist.BoolParam(name="def")
 
@@ -31,3 +34,17 @@ def test_param_resource_override_name():
     resource = DemoPage()
     args = resource.parse_args(request)
     assert args["def"] is True
+
+
+def test_param_resource_error():
+
+    request = DummyRequest("/")
+    request.addArg(b"id", b"1234")
+    request.addArg(b"uuid", b"1234")
+
+    resource = DemoPage()
+
+    with pytest.raises(Error) as exc_info:
+        resource.parse_args(request)
+
+    assert exc_info.value.message == b"Error in parameter uuid: Malformed UUID"

--- a/tests/test_param_resource.py
+++ b/tests/test_param_resource.py
@@ -47,4 +47,4 @@ def test_param_resource_error():
     with pytest.raises(Error) as exc_info:
         resource.parse_args(request)
 
-    assert exc_info.value.message == b"Error in parameter uuid: Malformed UUID"
+    assert exc_info.value.message == b"Error in parameter uuid: %s" % retwist.UUIDParam.MALFORMED_ERROR_MSG

--- a/tests/test_param_resource.py
+++ b/tests/test_param_resource.py
@@ -47,4 +47,4 @@ def test_param_resource_error():
     with pytest.raises(Error) as exc_info:
         resource.parse_args(request)
 
-    assert exc_info.value.message == b"Error in parameter uuid: %s" % retwist.UUIDParam.MALFORMED_ERROR_MSG
+    assert exc_info.value.message == retwist.ParamResource.ERROR_MSG % (b"uuid", retwist.UUIDParam.MALFORMED_ERROR_MSG)


### PR DESCRIPTION
Improvement: in py3 retwist will no longer render the b' prefix before the param error message.